### PR TITLE
fix:  preview_timestamp to be added only when its available

### DIFF
--- a/src/lib/stack.ts
+++ b/src/lib/stack.ts
@@ -149,7 +149,8 @@ export class Stack {
         ...this.config.live_preview,
         live_preview: query.live_preview || 'init',
         contentTypeUid: query.contentTypeUid,
-        entryUid: query.entryUid
+        entryUid: query.entryUid,
+        preview_timestamp: query.preview_timestamp || "",
       }
       this._client.stackConfig.live_preview = livePreviewParams;
     }


### PR DESCRIPTION
Preview timestamp doesnt clear when user switches back to LP from Timeline Preview. To reset it, we add preview_timestamp only when its available in query.