### PR TITLE
fix for sync method not working correctly

### DIFF
--- a/src/lib/synchronization.ts
+++ b/src/lib/synchronization.ts
@@ -15,7 +15,7 @@ export async function synchronization(client: AxiosInstance, params: SyncStack |
     config.params = { ...config.params, type: type.join(',') };
   }
 
-  let response: AxiosResponse = await getData(client, '/sync', { params: humps.decamelizeKeys(config) });
+  let response: AxiosResponse = await getData(client, '/stack/sync', { params: humps.decamelizeKeys(config.params) });
   const data = response.data;
 
   while (recursive && 'pagination_token' in response.data) {

--- a/src/lib/synchronization.ts
+++ b/src/lib/synchronization.ts
@@ -15,7 +15,7 @@ export async function synchronization(client: AxiosInstance, params: SyncStack |
     config.params = { ...config.params, type: type.join(',') };
   }
 
-  let response: AxiosResponse = await getData(client, '/stack/sync', { params: humps.decamelizeKeys(config.params) });
+  let response: AxiosResponse = await getData(client, '/stacks/sync', { params: humps.decamelizeKeys(config.params) });
   const data = response.data;
 
   while (recursive && 'pagination_token' in response.data) {

--- a/test/unit/synchronization.spec.ts
+++ b/test/unit/synchronization.spec.ts
@@ -28,63 +28,63 @@ describe('Synchronization function', () => {
   };
   it('should have valid init and environment params as req params when no request params is passed', async () => {
     await await synchronization(httpClient({}));
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('init');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({ init: true });
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('init');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({ init: true });
   });
 
   it('should have only pagination_token param when sync is called with pagination_token.', async () => {
     await syncCall({ paginationToken: '<page_tkn>' });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
     expect(getDataMock.mock.calls[0][2].params).not.toHaveProperty('init');
     expect(getDataMock.mock.calls[0][2].params).not.toHaveProperty('environment');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('pagination_token');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({ pagination_token: '<page_tkn>' });
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('pagination_token');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({ pagination_token: '<page_tkn>' });
   });
   it('should have only sync_token param when sync is called with sync_token.', async () => {
     await syncCall({ syncToken: '<sync_tkn>' });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
     expect(getDataMock.mock.calls[0][2].params).not.toHaveProperty('init');
     expect(getDataMock.mock.calls[0][2].params).not.toHaveProperty('environment');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('sync_token');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({ sync_token: '<sync_tkn>' });
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('sync_token');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({ sync_token: '<sync_tkn>' });
   });
   it('should have valid content_type_uid when content_type_uid is passed as param', async () => {
     await syncCall({ contentTypeUid: 'session' });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('init');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('content_type_uid');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('init');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('content_type_uid');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({
       init: true,
       content_type_uid: 'session',
     });
   });
   it('should have valid locale when a locale is passed as param', async () => {
     await syncCall({ locale: LOCALE });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('init');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('locale');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('init');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('locale');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({
       init: true,
       locale: LOCALE,
     });
   });
   it('should have valid date structure and other required params when start_date is passed as param', async () => {
     await syncCall({ startDate: '2018-10-22' });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('init');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('start_date');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('init');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('start_date');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({
       init: true,
       start_date: '2018-10-22',
     });
   });
   it('should have valid publish_type when type is passed as param', async () => {
     await syncCall({ type: [PublishType.ENTRY_PUBLISHED] });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('init');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('type');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('init');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('type');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({
       init: true,
       type: 'entry_published',
     });
@@ -95,10 +95,10 @@ describe('Synchronization function', () => {
       startDate: '2018-10-22',
       type: [PublishType.ENTRY_PUBLISHED, PublishType.CONTENT_TYPE_DELETED],
     });
-    expect(getDataMock.mock.calls[0][1]).toBe('/sync');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('init');
-    expect(getDataMock.mock.calls[0][2].params.params).toHaveProperty('type');
-    expect(getDataMock.mock.calls[0][2].params.params).toEqual({
+    expect(getDataMock.mock.calls[0][1]).toBe('/stacks/sync');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('init');
+    expect(getDataMock.mock.calls[0][2].params).toHaveProperty('type');
+    expect(getDataMock.mock.calls[0][2].params).toEqual({
       init: true,
       start_date: '2018-10-22',
       locale: 'en-us',


### PR DESCRIPTION
I couldn't get the sync method working, so I took a look and noticed two issues:
- the URL used in the call is incorrect, it states '/sync' but it should be '/stacks/sync'
- the way query parameters are passed to the getData call is incorrect, it provides the object holding the parameters instead of the parameters themselves