### PR TITLE
test: fix test case to parse error object instead of just string message

### DIFF
--- a/test/api/live-preview.spec.ts
+++ b/test/api/live-preview.spec.ts
@@ -131,7 +131,7 @@ describe("Live preview query Entry API tests", () => {
       expect(result.updated_by).toBeDefined();
     } catch (error: any) {
       expect(error).toBeDefined();
-      const errorData = JSON.parse(error.message);
+      const errorData = JSON.parse(error);
       expect(errorData.status).toEqual(403);
     }
   });


### PR DESCRIPTION
Fixed a test case in Live Preview API where the catch block was incorrectly parsing only `error.message` with `JSON.parse` instead of handling the entire error object. This caused incomplete or inaccurate error handling in the test.

**Changes**
- Updated the test case to parse the full error object instead of just error.message.
- Ensured error handling reflects the complete error structure for accurate validation.

**Impact**
This fix improves reliability of error handling in the Live Preview API test cases.