### PR TITLE
Fix locale error status code assertions to support 400 and 141

### DIFF
--- a/test/api/locale-fallback-chain.spec.ts
+++ b/test/api/locale-fallback-chain.spec.ts
@@ -146,9 +146,10 @@ describe('Locale Fallback Chain Tests', () => {
           locale: result.locale
         });
       } catch (error: any) {
-        if (error.status === 422) {
-          console.log('⚠️ API returned 422 for non-existent locale (expected behavior)');
-          expect(error.status).toBe(422);
+        // API can return 422, 400, or 141 for invalid/non-existent locale
+        if (error.status === 422 || error.status === 400 || error.status === 141) {
+          console.log(`⚠️ API returned ${error.status} for non-existent locale (expected behavior)`);
+          expect([422, 400, 141]).toContain(error.status);
         } else {
           throw error;
         }
@@ -346,9 +347,10 @@ describe('Locale Fallback Chain Tests', () => {
           hasContent: !!result.title
         });
       } catch (error: any) {
-        if (error.status === 422) {
-          console.log('⚠️ API rejected invalid locale format (expected)');
-          expect(error.status).toBe(422);
+        // API can return 422, 400, or 141 for invalid locale format
+        if (error.status === 422 || error.status === 400 || error.status === 141) {
+          console.log(`⚠️ API rejected invalid locale format with status ${error.status} (expected)`);
+          expect([422, 400, 141]).toContain(error.status);
         } else {
           throw error;
         }


### PR DESCRIPTION
Updated locale fallback chain tests to handle multiple valid API error status codes (422, 400, 141) for invalid/non-existent locale scenarios, aligning with JS CDA SDK behavior.