### PR TITLE
SDK Cortex generated API tests for ts_cda

### DIFF
--- a/test/api/sdk-cortex/regex.spec.ts
+++ b/test/api/sdk-cortex/regex.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { stackInstance } from '../../utils/stack-instance';
+
+const ctUid = process.env.SIMPLE_CONTENT_TYPE_UID;
+
+describe('Query.regex API tests', () => {
+  beforeAll(() => {
+    if (!ctUid) {
+      throw new Error('Required env var SIMPLE_CONTENT_TYPE_UID is not set');
+    }
+  });
+
+  it('should return entries matching a restrictive regex pattern on the title field', async () => {
+    const stack = stackInstance();
+    const result = await stack
+      .contentType(ctUid!)
+      .entry()
+      .query()
+      .regex('title', '^[A-Za-z]')
+      .find<{ title: string }>();
+
+    expect(result).toBeDefined();
+    expect(result.entries).toBeDefined();
+    if (result.entries && result.entries.length > 0) {
+      result.entries.forEach((entry) => {
+        expect(typeof entry.title).toBe('string');
+        expect(entry.title).toMatch(/^[A-Za-z]/);
+      });
+    }
+  });
+
+  it('should return entries matching a regex pattern with options (case-insensitive)', async () => {
+    const stack = stackInstance();
+    const result = await stack
+      .contentType(ctUid!)
+      .entry()
+      .query()
+      .regex('title', '[a-z]', 'i')
+      .find<{ title: string }>();
+
+    expect(result).toBeDefined();
+    expect(result.entries).toBeDefined();
+    if (result.entries && result.entries.length > 0) {
+      result.entries.forEach((entry) => {
+        expect(typeof entry.title).toBe('string');
+        expect(entry.title).toMatch(/[a-z]/i);
+      });
+    }
+  });
+
+  it('should handle an escaped regex pattern without throwing (DX-5325)', async () => {
+    const stack = stackInstance();
+    // Escaped pattern: "debt\?" — previously rejected by the SDK validator
+    // We use a safe variant that matches a literal question mark optionally
+    let result: Awaited<ReturnType<ReturnType<ReturnType<ReturnType<ReturnType<typeof stack.contentType>['entry']>['query']>['regex']>['find']>> | undefined;
+    let thrownError: unknown;
+    try {
+      result = await stack
+        .contentType(ctUid!)
+        .entry()
+        .query()
+        .regex('title', 'test\\?')
+        .find<{ title: string }>();
+    } catch (err) {
+      thrownError = err;
+    }
+
+    // The fix for DX-5325 ensures escaped patterns are accepted; no SDK-level validation error should be thrown
+    expect(thrownError).toBeUndefined();
+    expect(result).toBeDefined();
+    expect(result!.entries).toBeDefined();
+  });
+});


### PR DESCRIPTION
Generated by SDK Cortex.

SDK: `ts_cda`
Base branch: `main`

Generated tests:
- `test/api/sdk-cortex/regex.spec.ts` (regex)

Validation:
- regex: generated - generated output passed static and native validation: npx --no-install tsc --noEmit passed | npx --no-install jest test/api/sdk-cortex/regex.spec.ts --runInBand passed: 📦 report is created on: /private/var/folders/10/19j4fqb96w7_c8dhdpvg5wr80000gq/T/sdk-cortex-validation-v7q6_b5y/worktree/reports/contentstack-delivery/html/index.html
✅ Test results written to: test-results/jest-results.json
------------------------|---------|----------|---------|---------|-----------------------------------------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                   
------------------------|---------|----------|---------|---------|-----------------------------------------------------
All files               |   31.48 |    16.26 |   17.94 |   31.06 |                                                     
 assets                 |    7.07 |        0 |       0 |    6.18 |                                                     
  asset.ts              |    7.69 |        0 |       0 |       8 | 6-169                                               
  image-transform.ts    |     2.4 |        0 |       0 |    2.85 | 15-571                                              
  index.ts              |     100 |      100 |       0 |     100 |                                                     
 cache                  |    6.81 |        0 |       0 |    6.97 |                                                     
  index.ts              |    6.81 |        0 |       0 |    6.97 | 10-37,58-131                                        
 common                 |   77.37 |       62 |   66.66 |   78.35 |                                                     
  error-messages.ts     |   76.92 |    33.33 |      25 |   76.92 | 10-28                                               
  pagination.ts         |   14.28 |        0 |      25 |   16.66 | 36-110                                              
  string-extensions.ts  |       0 |        0 |       0 |       0 | 10-19                                               
  types.ts              |     100 |      100 |     100 |     100 |                                                     
  utils.ts              |   43.75 |    14.28 |   66.66 |      40 | 7,24-38                                             
 content-type           |   66.66 |        0 |   66.66 |   76.92 |                                                     
  index.ts              |   66.66 |        0 |   66.66 |   76.92 | 55-59                                               
 entries                |   15.03 |        0 |    8.82 |   13.95 |                                                     
  entries.ts            |   18.57 |        0 |   11.76 |   18.84 | 33-239,272-331                                      
  entry.ts              |    5.08 |        0 |       0 |    5.17 | 13-295                                              
  index.ts              |     100 |      100 |      50 |     100 |                                                     
 global-field           |   22.22 |      100 |       0 |   22.22 |                                                     
  index.ts              |   22.22 |      100 |       0 |   22.22 | 6-44                                                
 query                  |   24.54 |    11.59 |   12.69 |   22.43 |                                                     
  asset-query.ts        |    12.5 |        0 |       0 |    12.5 | 7-163                                               
  base-query.ts         |   13.15 |        0 |    8.33 |   13.51 | 19-256                                              
  contenttype-query.ts  |   22.22 |      100 |       0 |   22.22 | 7-45                                                
  entry-queryable.ts    |     100 |      100 |     100 |     100 |                                                     
  global-field-query.ts |   28.57 |      100 |       0 |   28.57 | 7-26                                                
  index.ts              |     100 |      100 |   28.57 |     100 |                                                     
  query.ts              |   21.26 |    13.11 |   17.85 |   20.93 | 20,23,39,45-90,109-110,113,143-629,642,655          
  taxonomy-query.ts     |      40 |      100 |       0 |      40 | 6-8                                                 
 stack                  |   40.42 |    11.76 |   14.81 |   40.15 |                                                     
  contentstack.ts       |   40.47 |    15.21 |    8.33 |   40.96 | 55,60,65,69,74-82,88,92,103-110,117-171,177,183-198 
  index.ts              |     100 |      100 |   33.33 |     100 |                                                     
  stack.ts              |   30.61 |     4.54 |   16.66 |   31.81 | 40-42,65-254                                        
 sync                   |   27.77 |        0 |       0 |   23.52 |                                                     
  index.ts              |     100 |      100 |       0 |     100 |                                                     
  synchronization.ts    |   18.75 |        0 |       0 |   18.75 | 7-34                                                
------------------------|---------|----------|---------|---------|-----------------------------------------------------

Artifacts:
- Markdown report: `reports/ts_cda.pr340.20260525T213510915547Z.analysis.md`
- HTML report: `reports/ts_cda.pr340.20260525T213510915547Z.analysis.html`
- Generated patch: `reports/ts_cda.pr340.20260525T213510915547Z.generated_patch.diff`