### PR TITLE
fix(DX-10060): retry transient network errors to prevent build crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Version: 5.5.1
+### Version: 5.6.0
 #### Date: Aug-03-2026
 Fix: Transient network-layer errors (ENOTFOUND, ENETUNREACH, ECONNRESET, ECONNREFUSED, EAI_AGAIN, ETIMEDOUT, EHOSTUNREACH, ENETDOWN) are now retried automatically using the SDK's configured retry policy instead of failing immediately.
 Enhancement: User-supplied `retryCondition` is composed with the default network-error retry logic — both are honoured without either replacing the other. If `retryCondition` throws, the SDK logs a warning via `logHandler` and falls back to default retry behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version: 5.5.1
+#### Date: Aug-03-2026
+Fix: Transient network-layer errors (ENOTFOUND, ENETUNREACH, ECONNRESET, ECONNREFUSED, EAI_AGAIN, ETIMEDOUT, EHOSTUNREACH, ENETDOWN) are now retried automatically using the SDK's configured retry policy instead of failing immediately.
+Enhancement: User-supplied `retryCondition` is composed with the default network-error retry logic — both are honoured without either replacing the other. If `retryCondition` throws, the SDK logs a warning via `logHandler` and falls back to default retry behaviour.
+
 ### Version: 5.5.0
 #### Date: Jul-27-2026
 Enhancement: Entry variants support an optional branch name as the second argument to `variants()` on `Entry` and `Entries`. When provided, the branch is sent as the `branch` request header together with `x-cs-variant-uid`. Existing `variants(uid)` and `variants(uids)` calls remain backward compatible. Added unit and API tests for variant + branch requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Version: 5.6.0
-#### Date:
+#### Date: Aug-05-2026
 Fix: Transient network-layer errors (ENOTFOUND, ENETUNREACH, ECONNRESET, ECONNREFUSED, EAI_AGAIN, ETIMEDOUT, EHOSTUNREACH, ENETDOWN) are now retried automatically using the SDK's configured retry policy instead of failing immediately.
 Enhancement: User-supplied `retryCondition` is composed with the default network-error retry logic — both are honoured without either replacing the other. If `retryCondition` throws, the SDK logs a warning via `logHandler` and falls back to default retry behaviour.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/delivery-sdk",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "type": "module",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/delivery-sdk",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "type": "module",
   "license": "MIT",
   "engines": {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -16,27 +16,20 @@ export function isBrowser() {
 }
 
 /**
- * Node.js/libuv error codes representing transient, retryable network-layer
- * failures (DNS resolution, connection reset/refused, no route to host, etc.),
- * plus Axios's own client-side timeout/abort signal ('ECONNABORTED'). All of
- * these occur before an HTTP response is received, so `error.response` is
- * undefined for all of them.
- *
- * 'ECONNABORTED' is included deliberately: @contentstack/core's own timeout
- * handling never retries it (it throws immediately on the first occurrence),
- * so without this, a single transient timeout has the same crash-the-caller
- * effect as an unretried DNS failure.
+ * Node.js/libuv error codes that represent transient, retryable network-layer
+ * failures. All occur before an HTTP response is received (error.response is
+ * undefined). ECONNABORTED is excluded — @contentstack/core handles it as a
+ * structured TIMEOUT error and it should not be retried here.
  */
 export const TRANSIENT_NETWORK_ERROR_CODES: ReadonlySet<string> = new Set([
-  'ENOTFOUND',
-  'ENETUNREACH',
-  'ECONNRESET',
-  'ECONNREFUSED',
-  'EAI_AGAIN',
-  'ETIMEDOUT',
-  'EHOSTUNREACH',
-  'ENETDOWN',
-  'ECONNABORTED',
+  'ENOTFOUND',    // DNS resolution failed
+  'ENETUNREACH',  // no route to host
+  'ECONNRESET',   // connection reset mid-flight
+  'ECONNREFUSED', // port closed / service not listening
+  'EAI_AGAIN',    // DNS server returned SERVFAIL (transient)
+  'ETIMEDOUT',    // OS-level connection timeout
+  'EHOSTUNREACH', // no route to host at IP layer
+  'ENETDOWN',     // local network interface down
 ]);
 
 /**

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -41,7 +41,7 @@ export const TRANSIENT_NETWORK_ERROR_CODES: ReadonlySet<string> = new Set([
  * @returns {boolean} True if `error.code` matches a known transient network error code
  */
 export function isTransientNetworkError(error: any): boolean {
-  return !!error && typeof error.code === 'string' && TRANSIENT_NETWORK_ERROR_CODES.has(error.code);
+  return !!error && typeof error.code === 'string' && !error.response && TRANSIENT_NETWORK_ERROR_CODES.has(error.code);
 }
 
 /**

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -16,6 +16,42 @@ export function isBrowser() {
 }
 
 /**
+ * Node.js/libuv error codes representing transient, retryable network-layer
+ * failures (DNS resolution, connection reset/refused, no route to host, etc.),
+ * plus Axios's own client-side timeout/abort signal ('ECONNABORTED'). All of
+ * these occur before an HTTP response is received, so `error.response` is
+ * undefined for all of them.
+ *
+ * 'ECONNABORTED' is included deliberately: @contentstack/core's own timeout
+ * handling never retries it (it throws immediately on the first occurrence),
+ * so without this, a single transient timeout has the same crash-the-caller
+ * effect as an unretried DNS failure.
+ */
+export const TRANSIENT_NETWORK_ERROR_CODES: ReadonlySet<string> = new Set([
+  'ENOTFOUND',
+  'ENETUNREACH',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETDOWN',
+  'ECONNABORTED',
+]);
+
+/**
+ * Determines whether an error represents a transient, retryable network-layer
+ * failure (e.g. DNS lookup failure, connection reset), used to build the SDK's
+ * default retry behavior so a single blip doesn't crash the caller (e.g. a
+ * Next.js static build) instead of being silently retried.
+ * @param {any} error - The error thrown by the underlying HTTP client (Axios)
+ * @returns {boolean} True if `error.code` matches a known transient network error code
+ */
+export function isTransientNetworkError(error: any): boolean {
+  return !!error && typeof error.code === 'string' && TRANSIENT_NETWORK_ERROR_CODES.has(error.code);
+}
+
+/**
  * Encodes query parameters recursively, handling nested objects
  * @param {params} params - Query parameters object to encode
  * @returns {params} Encoded query parameters object

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -38,7 +38,7 @@ export const TRANSIENT_NETWORK_ERROR_CODES: ReadonlySet<string> = new Set([
  * default retry behavior so a single blip doesn't crash the caller (e.g. a
  * Next.js static build) instead of being silently retried.
  * @param {any} error - The error thrown by the underlying HTTP client (Axios)
- * @returns {boolean} True if `error.code` matches a known transient network error code
+ * @returns {boolean} True if `error.code` matches a known transient network error code and no HTTP response was received (`error.response` is absent)
  */
 export function isTransientNetworkError(error: any): boolean {
   return !!error && typeof error.code === 'string' && !error.response && TRANSIENT_NETWORK_ERROR_CODES.has(error.code);

--- a/src/stack/contentstack.ts
+++ b/src/stack/contentstack.ts
@@ -178,8 +178,10 @@ export function stack(config: StackConfig): StackClass {
   // itself is never mutated, so stack.config / client.defaults keep reflecting
   // exactly what the consumer passed in.
   const combinedRetryCondition = (error: any) => {
-    if (config.retryCondition && config.retryCondition(error)) {
-      return true;
+    try {
+      if (config.retryCondition?.(error)) return true;
+    } catch (e) {
+      config.logHandler?.('warn', `[Contentstack SDK] retryCondition callback threw: "${(e as Error)?.message ?? e}". Check your retryCondition implementation. Falling back to default network-error retry behavior.`);
     }
     return Utility.isTransientNetworkError(error);
   };

--- a/src/stack/contentstack.ts
+++ b/src/stack/contentstack.ts
@@ -174,14 +174,17 @@ export function stack(config: StackConfig): StackClass {
 
   // Retry policy handlers.
   // Network-layer errors (DNS failures, connection resets, etc.) are retried
-  // by default, composed on top of any user-supplied retryCondition. `config`
-  // itself is never mutated, so stack.config / client.defaults keep reflecting
-  // exactly what the consumer passed in.
+  // by default, composed on top of any user-supplied retryCondition.
+  // The user's retryCondition reference is never replaced — only wrapped.
   const combinedRetryCondition = (error: any) => {
     try {
       if (config.retryCondition?.(error)) return true;
     } catch (e) {
-      config.logHandler?.('warn', `[Contentstack SDK] retryCondition callback threw: "${(e as Error)?.message ?? e}". Check your retryCondition implementation. Falling back to default network-error retry behavior.`);
+      config.logHandler?.('warn', {
+        type: 'retry_condition_error',
+        message: `[Contentstack SDK] retryCondition callback threw: "${(e as Error)?.message ?? e}". Check your retryCondition implementation. Falling back to default network-error retry behavior.`,
+        error: e,
+      });
     }
     return Utility.isTransientNetworkError(error);
   };

--- a/src/stack/contentstack.ts
+++ b/src/stack/contentstack.ts
@@ -172,9 +172,19 @@ export function stack(config: StackConfig): StackClass {
     }
   }
 
-  // Retry policy handlers
+  // Retry policy handlers.
+  // Network-layer errors (DNS failures, connection resets, etc.) are retried
+  // by default, composed on top of any user-supplied retryCondition. `config`
+  // itself is never mutated, so stack.config / client.defaults keep reflecting
+  // exactly what the consumer passed in.
+  const combinedRetryCondition = (error: any) => {
+    if (config.retryCondition && config.retryCondition(error)) {
+      return true;
+    }
+    return Utility.isTransientNetworkError(error);
+  };
   const errorHandler = (error: any) => {
-    return retryResponseErrorHandler(error, config, client);
+    return retryResponseErrorHandler(error, { ...config, retryCondition: combinedRetryCondition }, client);
   };
   client.interceptors.request.use(retryRequestHandler);
   client.interceptors.response.use(retryResponseHandler, errorHandler);

--- a/test/unit/network-error-retry.spec.ts
+++ b/test/unit/network-error-retry.spec.ts
@@ -148,8 +148,8 @@ describe('Default network-error retry behavior', () => {
     expect(res.status).toBe(200);
   });
 
-  it('(g) retryCondition that throws is caught — warning logged and SDK falls back to default retry', async () => {
-    const warnMessages: string[] = [];
+  it('(g) retryCondition that throws is caught — structured warning logged and SDK falls back to default retry', async () => {
+    const warnPayloads: any[] = [];
     const throwingCondition = () => { throw new Error('boom'); };
     const config: StackConfig = {
       apiKey: 'TEST-API-KEY',
@@ -158,14 +158,13 @@ describe('Default network-error retry behavior', () => {
       retryDelay: 10,
       retryCondition: throwingCondition,
       logHandler: (level: string, msg: any) => {
-        if (level === 'warn') warnMessages.push(msg);
+        if (level === 'warn') warnPayloads.push(msg);
       },
     };
     const stack = Contentstack.stack(config);
     const client = stack.getClient();
     mockClient = new MockAdapter(client);
 
-    // SDK should fall back to default network-error retry and succeed.
     mockClient
       .onGet('/content_types/test')
       .replyOnce(dnsError('ENOTFOUND'))
@@ -174,9 +173,93 @@ describe('Default network-error retry behavior', () => {
 
     const res = await client.get('/content_types/test');
     expect(res.status).toBe(200);
-    expect(warnMessages.length).toBeGreaterThan(0);
-    expect(warnMessages[0]).toContain('[Contentstack SDK]');
-    expect(warnMessages[0]).toContain('boom');
+    expect(warnPayloads.length).toBeGreaterThan(0);
+    expect(warnPayloads[0]).toEqual(expect.objectContaining({ type: 'retry_condition_error' }));
+    expect(warnPayloads[0].message).toContain('[Contentstack SDK]');
+    expect(warnPayloads[0].message).toContain('boom');
+  });
+
+  it('(h1) retryCondition throws a non-Error (string) — ?? fallback logs the raw thrown value', async () => {
+    const warnPayloads: any[] = [];
+    const throwingCondition = () => { throw 'not-an-error-object'; };
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryDelay: 10,
+      retryCondition: throwingCondition,
+      logHandler: (level: string, msg: any) => {
+        if (level === 'warn') warnPayloads.push(msg);
+      },
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ENOTFOUND'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+    expect(warnPayloads[0]).toEqual(expect.objectContaining({ type: 'retry_condition_error' }));
+    // message uses the raw thrown value via the ?? fallback since it has no .message
+    expect(warnPayloads[0].message).toContain('not-an-error-object');
+  });
+
+  it('(h) retryCondition that throws with no logHandler — SDK falls back silently without throwing', async () => {
+    const throwingCondition = () => { throw new Error('boom'); };
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryDelay: 10,
+      retryCondition: throwingCondition,
+      // no logHandler — exercises the logHandler?. undefined branch
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ENOTFOUND'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('(k) retryCondition returning true triggers retry even for non-transient-code errors', async () => {
+    // Covers the `if (config.retryCondition?.(error)) return true` branch.
+    const alwaysRetry = jest.fn().mockReturnValue(true);
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryDelay: 10,
+      retryCondition: alwaysRetry,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    // Use a generic error with no recognized code — only user retryCondition covers it.
+    const genericError = (cfg: any) =>
+      Promise.reject(Object.assign(new Error('generic'), { config: cfg, isAxiosError: true }));
+
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(genericError)
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+    expect(alwaysRetry).toHaveBeenCalled();
   });
 
   it('(i) retryOnError: false disables network-error retries — ENOTFOUND throws immediately', async () => {

--- a/test/unit/network-error-retry.spec.ts
+++ b/test/unit/network-error-retry.spec.ts
@@ -21,9 +21,9 @@ describe('Default network-error retry behavior', () => {
 
   it('(a) retries and succeeds after a single transient ENOTFOUND failure with no custom retryCondition', async () => {
     const config: StackConfig = {
-      apiKey: 'test-api-key',
-      deliveryToken: 'test-delivery-token',
-      environment: 'test-environment',
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
       retryDelay: 10,
     };
     const stack = Contentstack.stack(config);
@@ -42,9 +42,9 @@ describe('Default network-error retry behavior', () => {
 
   it('(b) still fails after retryLimit is exhausted on a permanent network failure', async () => {
     const config: StackConfig = {
-      apiKey: 'test-api-key',
-      deliveryToken: 'test-delivery-token',
-      environment: 'test-environment',
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
       retryLimit: 2,
       retryDelay: 10,
     };
@@ -60,9 +60,9 @@ describe('Default network-error retry behavior', () => {
   it('(c) composes with a user-supplied retryCondition without replacing it', async () => {
     const userCondition = jest.fn((error: any) => error?.response?.status === 500);
     const config: StackConfig = {
-      apiKey: 'test-api-key',
-      deliveryToken: 'test-delivery-token',
-      environment: 'test-environment',
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
       retryDelay: 10,
       retryCondition: userCondition,
     };
@@ -84,11 +84,14 @@ describe('Default network-error retry behavior', () => {
     expect(stack.config.retryCondition).toBe(userCondition);
   });
 
-  it('(d) ECONNABORTED/timeout errors are unaffected by the new network-retry path', async () => {
+  it('(d) ECONNABORTED (axios timeout) is NOT retried — core classifies it as a structured TIMEOUT error', async () => {
+    // ECONNABORTED is excluded from TRANSIENT_NETWORK_ERROR_CODES so that
+    // @contentstack/core can surface it as { error_code: "TIMEOUT" } (#239).
+    // Retrying it here would bypass that structured classification.
     const config: StackConfig = {
-      apiKey: 'test-api-key',
-      deliveryToken: 'test-delivery-token',
-      environment: 'test-environment',
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
       retryDelay: 10,
     };
     const stack = Contentstack.stack(config);
@@ -96,6 +99,97 @@ describe('Default network-error retry behavior', () => {
     mockClient = new MockAdapter(client);
 
     mockClient.onGet('/content_types/test').timeout();
+
+    await expect(client.get('/content_types/test')).rejects.toBeDefined();
+  });
+
+  it('(e) ENETUNREACH and ETIMEDOUT (the customer-reported codes) are retried', async () => {
+    for (const code of ['ENETUNREACH', 'ETIMEDOUT'] as const) {
+      const config: StackConfig = {
+        apiKey: 'TEST-API-KEY',
+        deliveryToken: 'TEST-DELIVERY-TOKEN',
+        environment: 'TEST-ENVIRONMENT',
+        retryDelay: 10,
+      };
+      const stack = Contentstack.stack(config);
+      const client = stack.getClient();
+      const mock = new MockAdapter(client);
+
+      mock
+        .onGet('/content_types/test')
+        .replyOnce(dnsError(code))
+        .onGet('/content_types/test')
+        .reply(200, { content_types: [] });
+
+      const res = await client.get('/content_types/test');
+      expect(res.status).toBe(200);
+      mock.restore();
+    }
+  });
+
+  it('(f) EAI_AGAIN (DNS servfail, intermittent) is retried', async () => {
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryDelay: 10,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('EAI_AGAIN'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('(g) retryOnError: false disables network-error retries — ENOTFOUND throws immediately', async () => {
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryOnError: false,
+      retryDelay: 10,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    // Second route intentionally registered — if the SDK retried it would succeed,
+    // proving the test would only pass when retryOnError: false truly disables retry.
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ENOTFOUND'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    await expect(client.get('/content_types/test')).rejects.toBeDefined();
+  });
+
+  it('(h) retryLimit: 0 disables network-error retries — ENOTFOUND throws immediately', async () => {
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryLimit: 0,
+      retryDelay: 10,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    // Second route intentionally registered — if the SDK retried it would succeed,
+    // proving the test would only pass when retryLimit: 0 truly disables retry.
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ENOTFOUND'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
 
     await expect(client.get('/content_types/test')).rejects.toBeDefined();
   });

--- a/test/unit/network-error-retry.spec.ts
+++ b/test/unit/network-error-retry.spec.ts
@@ -148,7 +148,38 @@ describe('Default network-error retry behavior', () => {
     expect(res.status).toBe(200);
   });
 
-  it('(g) retryOnError: false disables network-error retries — ENOTFOUND throws immediately', async () => {
+  it('(g) retryCondition that throws is caught — warning logged and SDK falls back to default retry', async () => {
+    const warnMessages: string[] = [];
+    const throwingCondition = () => { throw new Error('boom'); };
+    const config: StackConfig = {
+      apiKey: 'TEST-API-KEY',
+      deliveryToken: 'TEST-DELIVERY-TOKEN',
+      environment: 'TEST-ENVIRONMENT',
+      retryDelay: 10,
+      retryCondition: throwingCondition,
+      logHandler: (level: string, msg: any) => {
+        if (level === 'warn') warnMessages.push(msg);
+      },
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    // SDK should fall back to default network-error retry and succeed.
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ENOTFOUND'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+    expect(warnMessages.length).toBeGreaterThan(0);
+    expect(warnMessages[0]).toContain('[Contentstack SDK]');
+    expect(warnMessages[0]).toContain('boom');
+  });
+
+  it('(i) retryOnError: false disables network-error retries — ENOTFOUND throws immediately', async () => {
     const config: StackConfig = {
       apiKey: 'TEST-API-KEY',
       deliveryToken: 'TEST-DELIVERY-TOKEN',
@@ -171,7 +202,7 @@ describe('Default network-error retry behavior', () => {
     await expect(client.get('/content_types/test')).rejects.toBeDefined();
   });
 
-  it('(h) retryLimit: 0 disables network-error retries — ENOTFOUND throws immediately', async () => {
+  it('(j) retryLimit: 0 disables network-error retries — ENOTFOUND throws immediately', async () => {
     const config: StackConfig = {
       apiKey: 'TEST-API-KEY',
       deliveryToken: 'TEST-DELIVERY-TOKEN',

--- a/test/unit/network-error-retry.spec.ts
+++ b/test/unit/network-error-retry.spec.ts
@@ -1,0 +1,102 @@
+import * as Contentstack from '../../src/stack';
+import { StackConfig } from '../../src/common/types';
+import MockAdapter from 'axios-mock-adapter';
+
+describe('Default network-error retry behavior', () => {
+  let mockClient: MockAdapter | undefined;
+
+  afterEach(() => {
+    mockClient?.restore();
+    mockClient = undefined;
+  });
+
+  const dnsError = (code: string) => (config: any) =>
+    Promise.reject(
+      Object.assign(new Error(`getaddrinfo ${code} example.com`), {
+        code,
+        config,
+        isAxiosError: true,
+      })
+    );
+
+  it('(a) retries and succeeds after a single transient ENOTFOUND failure with no custom retryCondition', async () => {
+    const config: StackConfig = {
+      apiKey: 'test-api-key',
+      deliveryToken: 'test-delivery-token',
+      environment: 'test-environment',
+      retryDelay: 10,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ENOTFOUND'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('(b) still fails after retryLimit is exhausted on a permanent network failure', async () => {
+    const config: StackConfig = {
+      apiKey: 'test-api-key',
+      deliveryToken: 'test-delivery-token',
+      environment: 'test-environment',
+      retryLimit: 2,
+      retryDelay: 10,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient.onGet('/content_types/test').reply(dnsError('ENOTFOUND'));
+
+    await expect(client.get('/content_types/test')).rejects.toBeDefined();
+  });
+
+  it('(c) composes with a user-supplied retryCondition without replacing it', async () => {
+    const userCondition = jest.fn((error: any) => error?.response?.status === 500);
+    const config: StackConfig = {
+      apiKey: 'test-api-key',
+      deliveryToken: 'test-delivery-token',
+      environment: 'test-environment',
+      retryDelay: 10,
+      retryCondition: userCondition,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient
+      .onGet('/content_types/test')
+      .replyOnce(dnsError('ECONNRESET'))
+      .onGet('/content_types/test')
+      .reply(200, { content_types: [] });
+
+    const res = await client.get('/content_types/test');
+    expect(res.status).toBe(200);
+    // config is never mutated — stack.config.retryCondition stays the exact
+    // user-supplied function, matching the identity assertion already made
+    // by test/unit/retry-configuration.spec.ts.
+    expect(stack.config.retryCondition).toBe(userCondition);
+  });
+
+  it('(d) ECONNABORTED/timeout errors are unaffected by the new network-retry path', async () => {
+    const config: StackConfig = {
+      apiKey: 'test-api-key',
+      deliveryToken: 'test-delivery-token',
+      environment: 'test-environment',
+      retryDelay: 10,
+    };
+    const stack = Contentstack.stack(config);
+    const client = stack.getClient();
+    mockClient = new MockAdapter(client);
+
+    mockClient.onGet('/content_types/test').timeout();
+
+    await expect(client.get('/content_types/test')).rejects.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Transient network-layer errors (`ENOTFOUND`, `ENETUNREACH`, `ECONNRESET`, `ECONNREFUSED`, `EAI_AGAIN`, `ETIMEDOUT`, `EHOSTUNREACH`, `ENETDOWN`) are now retried using the SDK's configured retry policy instead of failing immediately.
- A `combinedRetryCondition` composes any user-supplied `retryCondition` with the new default network-error check — the user condition runs first, the original config is never mutated.
- If the user-supplied `retryCondition` throws, a warning is emitted via `logHandler` and the SDK falls back to default retry behaviour.
- `ECONNABORTED` is intentionally excluded — `@contentstack/core` classifies it as a structured `TIMEOUT` error.
- Version bumped `5.5.0` → `5.6.0` (minor — crux retry logic changed).

## Test coverage

8 unit tests added covering: ENOTFOUND retry, ENETUNREACH/ETIMEDOUT (customer-reported codes), EAI_AGAIN, ECONNRESET composition with user retryCondition, ECONNABORTED exclusion, `retryOnError: false`, and `retryLimit: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)