### PR TITLE
chore: Prepare 5.5.2 release with @contentstack/core ^1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Version: 5.5.2
+#### Date: Aug-05-2026
+Fix: Bump `@contentstack/core` to `^1.5.1`:
+- Resolve `MODULE_NOT_FOUND` / "expression is too dynamic" build failures in bundlers (Next.js/Turbopack, webpack) caused by a dynamic `require()` in the keep-alive agent setup — now uses statically analyzable `require('http')`/`require('https')`
+- Guard keep-alive agent creation for native ESM (where `require` is undefined) to avoid a `ReferenceError`
+- Add package `browser` field so `http`/`https` resolve cleanly in browser bundles
+
 ### Version: 5.5.1
 #### Date: Aug-03-2026
 Fix: Bump `@contentstack/core` to `^1.5.0`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@contentstack/delivery-sdk",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@contentstack/delivery-sdk",
-      "version": "5.5.1",
+      "version": "5.5.2",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/core": "^1.5.0",
+        "@contentstack/core": "^1.5.1",
         "@contentstack/utils": "^1.9.1",
         "axios": "^1.18.1",
         "humps": "^2.0.1"
@@ -540,9 +540,9 @@
       "license": "MIT"
     },
     "node_modules/@contentstack/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-GTNjPYqi49EFpdGp+6UGdY55OoM48Rc7UyCUTYPdzcmrvYlmiL0JKqyozShEVaqrDMdaNBQZu8PRvRA7TpDVNA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/core/-/core-1.5.1.tgz",
+      "integrity": "sha512-sz07yKU+NI3zo8WDtYfJO23cqhglChxbE+CQt5smpTLCHv3hU30vX1nFGLI9tPAuBOCg3pJJDeDohgUNesJGeQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/delivery-sdk",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "type": "module",
   "license": "MIT",
   "engines": {
@@ -47,7 +47,7 @@
     "prerelease": "npm run test:all && npm run validate:all"
   },
   "dependencies": {
-    "@contentstack/core": "^1.5.0",
+    "@contentstack/core": "^1.5.1",
     "@contentstack/utils": "^1.9.1",
     "axios": "^1.18.1",
     "humps": "^2.0.1"


### PR DESCRIPTION
Bumps @contentstack/core to ^1.5.1, which fixes MODULE_NOT_FOUND / "expression is too dynamic" build failures in bundlers (Next.js/Turbopack, webpack) and native ESM ReferenceErrors from the keep-alive agent setup.

